### PR TITLE
[18] Ampliar las opciones del campo TIPO de las programaciones

### DIFF
--- a/programaciones/models.py
+++ b/programaciones/models.py
@@ -653,7 +653,9 @@ class ProgSec(models.Model):
              ('AAC', 'Adaptación de Acceso al Currículo'), ('AC', 'Adaptación Curricular'),
              ('ACS', 'Adaptación Curricular Significativa'), ('EC', 'Enriquecimiento Curricular'),
              ('PRE', 'Plan de Recuperación'), ('PRT', 'Programa de Refuerzo Transitorio'),
-             ('DIV', 'Diversificación Curricular'),)
+             ('DIV', 'Diversificación Curricular'), ('BIN', 'Bachillerato Internacional'),
+             ('BNO', 'Bachillerato Nocturno'), ('BDI', 'Bachillerato Distancia'),
+             ('EOI', 'Escuela Oficial Idiomas'),)
     pga = models.ForeignKey(PGA, on_delete=models.CASCADE)
     nombre = models.CharField('Nombre específico para la programación', blank=True, max_length=300)
     gep = models.ForeignKey(Gauser_extra_programaciones, blank=True, null=True, on_delete=models.CASCADE)

--- a/programaciones/views.py
+++ b/programaciones/views.py
@@ -2693,7 +2693,7 @@ def verprogramaciones(request, secret):
     try:
         entidad = Entidad.objects.get(secret=secret)
         pga = PGA.objects.get(ronda=entidad.ronda)
-        progsecs = ProgSec.objects.filter(pga=pga, tipo='DEF').order_by('areamateria__curso')
+        progsecs = ProgSec.objects.filter(pga=pga, tipo__in=('DEF', 'BIN', 'BNO', 'BDI', 'EOI')).order_by('areamateria__curso')
         return render(request, "verprogramaciones.html",
                       {
                           'formname': 'verprogramaciones',


### PR DESCRIPTION
Se han añadido al campo TIPO de las programaciones las opciones:
- Bachillerato internacional
- Bachillerato nocturno
- Bachillerato distancia
- EOI

Además, estas opciones, junto con la opción DEFINITIVA, son visibles en el enlace público _verprogramaciones_