### PR TITLE
[22] Contabilización correcta del número de SAPs en el PDF generado d…

### DIFF
--- a/programaciones/templates/verprogramacion.html
+++ b/programaciones/templates/verprogramacion.html
@@ -262,7 +262,7 @@
 {% for saber in progsec.get_saberes %}
 <h3 class="pagebreak" style="text-align: center;">{{ saber.orden }}.- {{ saber.nombre }} ({{ saber.periodos }}
     periodos)</h3>
-<p>Esta unidad de programación está compuesta por {{ saber.sitapren_set.all|length }} situaciones de aprendizaje
+<p>Esta unidad de programación está compuesta por {{ saber.get_sitaprens|length }} situaciones de aprendizaje
     que son descritas a continuación.</p>
 {% for sitapren in saber.get_sitaprens %}
 <h4>{{ sitapren.nombre }}</h4>


### PR DESCRIPTION
Para calcular el número de SAP's de la que estaba compuesta la unidad de programación en el PDF generado utilizaba el método `sitapren_set.all`, que trae todas las SAPs, borradas y no borradas. Lo cambiamos por `get_sitaprens`, propiedad creada en el modelo `SaberBas` para traer solo las SAP's no borradas.