### PR TITLE
[44] Cuaderno docente procedimientos. Mejora visibilidad de competencias, criterios y asignaturas

### DIFF
--- a/programaciones/templates/cuadernodocente.html
+++ b/programaciones/templates/cuadernodocente.html
@@ -1205,6 +1205,83 @@
                     }
                 });
         });
+        
+        // Mostramos ocultamos asignatura en la vista de competencias del cuaderno normal
+        $('body').on('click', '.ver_ocultar_asignatura', function(){
+            let asignatura_activa = $(this).attr("data-activo");
+            let asignatura = $(this).attr("trigger-toggle-asignatura");
+
+            // No jugamos con toggle, porque al tener dos switch, puede haber estados cambiados.
+            // Switch: Asignatura. Forzamos a encender o apagar todo.
+            if(asignatura_activa == "1") { // Si está activa, desactivamos.
+                $(this).attr("data-activo", "0");
+                $("[toggle-asignatura='"+asignatura+"']").hide();
+            }else {
+                $(this).attr("data-activo", "1");
+                $("[toggle-asignatura='"+asignatura+"']").show();
+            }
+
+            // Switch: criterios. Escondemos los elementos correspondientes si los criterios están desactivados
+            let criterios_activos = $(".ver_ocultar_criterios").attr("data-activo");
+
+            $("[th-competencias-long]").hide();     //Escondemos todas las cabeceras y vemos cuales mostramos
+            $("[th-competencias-short]").hide();
+            if(criterios_activos == "0")  { $("[toggle-criterio]").hide(); }
+
+            // Cabeceras
+            $(".ver_ocultar_asignatura").each(function(){
+                let asig_activ = $(this).attr("data-activo");
+                let asig = $(this).attr("trigger-toggle-asignatura");
+                if(asig_activ == "1"){
+                    if(criterios_activos == "0") {
+                        $("[th-competencias-short][toggle-asignatura='"+asig+"']").show();
+                    } else {
+                        $("[th-competencias-long][toggle-asignatura='"+asig+"']").show();
+                    }
+                }
+            })  
+
+            //Cambiamos estilo del pill
+            $(this).find("span").toggleClass("disabled");       
+            $(this).find(".fa").toggleClass("fa-eye");          //Cambiamos el icono
+            $(this).find(".fa").toggleClass("fa-eye-slash");    //Cambiamos el icono 
+
+        });
+
+
+        $('body').on('click', '.ver_ocultar_criterios', function(){
+            let criterios_activos = $(this).attr("data-activo");
+
+            // Switch: Criterios. Mostramos o escondemos todo
+            if(criterios_activos == "1") { //Si los criterios están activos, desactivamos
+                $(this).attr("data-activo", "0");
+                $("[toggle-criterio]").hide();
+
+                $("[th-competencias-long]").hide();
+                $("[th-competencias-short]").show();  
+            }else {
+                $(this).attr("data-activo", "1");
+                $("[toggle-criterio]").show();
+
+                $("[th-competencias-long]").show();
+                $("[th-competencias-short]").hide();   
+            }
+
+            // Switch: Asignaturas. Tenemos que recorrer todas las asignaturas para esconder las celdas correspondientes a una asginatura oculta
+            $(".ver_ocultar_asignatura").each(function(){
+                let asignatura_activa = $(this).attr("data-activo");
+                let asignatura = $(this).attr("trigger-toggle-asignatura");
+                if(asignatura_activa == "0"){
+                    $("[toggle-asignatura='"+asignatura+"']").hide();
+                }
+            })
+            
+        
+            $(this).find("span").toggleClass("disabled");       //Cambiamos estilo del pill
+            $(this).find(".fa").toggleClass("fa-eye");          //Cambiamos el icono
+            $(this).find(".fa").toggleClass("fa-eye-slash");    //Cambiamos el icono 
+
+        });
 
         $('body').on('click', '.ver_ocultar_sb', function(){
 
@@ -1214,7 +1291,7 @@
             if (sb == "show-all") {
                 
                 $(this).attr("data-toggle", "hide-all");
-                let group = $(this).closest(".ver_ocultar_sb_group");
+                let group = $(this).closest(".ver_ocultar_group");
                 
                 group.find(".ver_ocultar_sb").each(function(){
                     cuadernodocente_visualiza_saber_basico($(this), "hide");
@@ -1225,7 +1302,7 @@
             }else if (sb == "hide-all") {
                 $(this).attr("data-toggle", "show-all");
                 
-                let group = $(this).closest(".ver_ocultar_sb_group");
+                let group = $(this).closest(".ver_ocultar_group");
                 group.find(".ver_ocultar_sb").each(function(){
                     cuadernodocente_visualiza_saber_basico($(this), "show");
                 });
@@ -1293,9 +1370,9 @@
                 }else {
 
                     $('.' + sb).toggle();
-                                element.find("span").toggleClass("disabled");       //Cambiamos estilo del pill
-                                element.find(".fa").toggleClass("fa-eye");          //Cambiamos el icono
-                                element.find(".fa").toggleClass("fa-eye-slash");    //Cambiamos el icono 
+                    element.find("span").toggleClass("disabled");       //Cambiamos estilo del pill
+                    element.find(".fa").toggleClass("fa-eye");          //Cambiamos el icono
+                    element.find(".fa").toggleClass("fa-eye-slash");    //Cambiamos el icono 
                 }
                 
                 

--- a/programaciones/templates/cuadernodocente_content.html
+++ b/programaciones/templates/cuadernodocente_content.html
@@ -15,7 +15,7 @@
     .materia-curso {
         color: #f08a24;
         border-radius: 3px;
-        font-size: 1.1em;
+        font-size: 1em;
         font-weight: bold;
         display: inline-block;
     }
@@ -28,7 +28,6 @@
         overflow-x: auto;
         display: block;
         height: 550px;
-        
     }
 
     .fullscreen {
@@ -153,15 +152,16 @@
    
 
     /* Mostrar/ocultar unidades*/
-    .ver_ocultar_sb_group {
+    .ver_ocultar_group {
         padding: 10px;
         padding-bottom: 5px;
         background-color: #EFEFEF;
         border: 1px solid #DDDDDD;
         border-bottom: none;
+        margin-top: 20px;
     }
 
-    .ver_ocultar_sb span {
+    .ver_ocultar_item span {
         margin-bottom: 6px;
         margin-right: 6px;
         display: inline-block;
@@ -171,16 +171,20 @@
         color: white !important;
     }
 
-    .ver_ocultar_sb span:hover {
+    .ver_ocultar_criterios {
+        float: right;
+    }
+
+    .ver_ocultar_item span:hover {
         background-color: #00485f !important;
     }
-    .ver_ocultar_sb span.disabled {
+    .ver_ocultar_item span.disabled {
         background-color: white !important;
         border: 1px solid #DDDDDD !important;
         color: #222222 !important;
     }
 
-    .ver_ocultar_sb span.disabled:hover {
+    .ver_ocultar_item span.disabled:hover {
         background-color: #008CBA !important;
         color: white !important;
     }
@@ -206,17 +210,19 @@
              </a>
             </li>
 
-            <li style="margin-right: 20px;">
-                {% if cuaderno.vista == "NOR" %}
-                    <a class="button tiny cuaderno_competencias" data-cuaderno="{{ cuaderno.id }}" data-vista="COM" title="Ir a la vista de calificaciones por competencias específicas">
-                        <i class="fa fa-exchange"></i> Competencias
-                    </a>
-                {% else %}
-                    <a class="button tiny cuaderno_competencias" data-cuaderno="{{ cuaderno.id }}" data-vista="NOR" title="Ir a la vista de calificaciones por competencias específicas">
-                        <i class="fa fa-exchange"></i> Notas
-                    </a>
-                {% endif %}
-            </li>
+            {% if cuaderno.tipo == 'PRO' %}
+                <li style="margin-right: 20px;">
+                    {% if cuaderno.vista == "NOR" %}
+                        <a class="button tiny cuaderno_competencias" data-cuaderno="{{ cuaderno.id }}" data-vista="COM" title="Ir a la vista de calificaciones por competencias específicas">
+                            <i class="fa fa-exchange"></i> Competencias
+                        </a>
+                    {% else %}
+                        <a class="button tiny cuaderno_competencias" data-cuaderno="{{ cuaderno.id }}" data-vista="NOR" title="Ir a la vista de calificaciones por competencias específicas">
+                            <i class="fa fa-exchange"></i> Notas
+                        </a>
+                    {% endif %}
+                </li>
+            {% endif %}
 
 
             <li>
@@ -466,8 +472,8 @@
             {#{% elif cuaderno %}#}
            
             {% with estructura_cuaderno=cuaderno.estructura_cuaderno %}
-                <div class="ver_ocultar_sb_group">
-                    <!--a class="ver_ocultar_sb ver_ocultar_all" data-toggle="show-all"
+                <div class="ver_ocultar_group">
+                    <!--a class="ver_ocultar_item ver_ocultar_all" data-toggle="show-all"
                            title="Mostrar/ocultar todos">
                                 <span class="label info disabled" style="font-weight: bold;">
                                     <i class="fa fa-eye-slash"></i> TODOS
@@ -475,7 +481,7 @@
                     </a-->
                 
                 {% for sb in estructura_cuaderno %}
-                    <a class="ver_ocultar_sb" data-toggle="sb__{{ sb.sb.id }}"
+                    <a class="ver_ocultar_sb ver_ocultar_item" data-toggle="sb__{{ sb.sb.id }}"
                        title="Mostrar/ocultar {{ sb.sb.nombre }}">
                             <span class="label info disabled" style="font-weight: bold;">
                                 <i class="fa fa-eye-slash"></i> {{ sb.sb.nombre }}
@@ -650,6 +656,31 @@
             {% endwith %}
         {% else %}
             {% with num_asig=cuaderno.psec.ces_asignaturas_ambito|length caas=cuaderno.psec.ces_asignaturas_ambito %}
+
+                
+                <div class="ver_ocultar_group">
+                    {% for asignatura in caas %}
+                        <a class="ver_ocultar_asignatura ver_ocultar_item" 
+                            data-activo="1"
+                            trigger-toggle-asignatura="{{ asignatura }}"
+                            title="Mostrar/ocultar {{ asignatura }}">
+                                <span class="label info" style="font-weight: bold;">
+                                    <i class="fa fa-eye"></i> {{ asignatura }}
+                                </span>
+                        </a>
+                    {% endfor %}
+
+                    <a class="ver_ocultar_criterios ver_ocultar_item"
+                        data-activo="1"
+                        title="Mostrar/ocultar crietios">
+                         <span class="label info" style="font-weight: bold;">
+                             <i class="fa fa-eye"></i> Criterios
+                         </span>
+                    </a>
+                </div>
+                
+
+
                 <div class="div_table{{ cuaderno.id }}">
                     <table id="tabla{{ cuaderno.id }}" class="tabla_cuaderno">
                         <thead>
@@ -677,51 +708,71 @@
                             </th>
                             {% for ce in cuaderno.psec.areamateria.competenciaespecifica_set.all %}
                                 <th colspan="{{ ce.criterioevaluacion_set.all|length|add:'1' }}"
-                                    title="{{ ce.orden }}.- {{ ce.nombre }}">{{ ce.orden }}.-
-                                    {{ ce.nombre|truncatechars:160 }}</th>
+                                    title="{{ ce.orden }}.- {{ ce.nombre }}"
+                                    toggle-asignatura="{{ ce.asignatura }}"
+                                    th-competencias-long
+                                    >{{ ce.orden }}.-
+                                    {{ ce.nombre|truncatechars:100 }}
+                                </th>
+
+                                <th colspan="1" style="display: none;"
+                                title="{{ ce.orden }}.- {{ ce.nombre }}"
+                                toggle-asignatura="{{ ce.asignatura }}"
+                                th-competencias-short
+                                >{{ ce.orden }}.-
+                                {{ ce.nombre|truncatechars:20 }}
+                                </th>
+                                
                             {% endfor %}
                         </tr>
                         <tr>
                             {% for cev in cuaderno.psec.areamateria.cevs %}
                                 {% ifchanged cev.ce %}
-                                    <th title="Calificación global de la CE{{ cev.ce.orden }}">Cal.
-                                        CE{{ cev.ce.orden }}</th>
+                                    <th title="Calificación global de la CE{{ cev.ce.orden }}"
+                                    toggle-asignatura="{{ cev.ce.asignatura }}">
+                                    Cal.CE{{ cev.ce.orden }}</th>
                                 {% endifchanged %}
                                 <th title="{{ cev.ce.orden }}.{{ cev.orden }}.- {{ cev.texto }}"
-                                >{{ cev.ce.orden }}.{{ cev.orden }}.- {{ cev.texto|truncatechars:20 }}</th>
+                                toggle-asignatura="{{ cev.ce.asignatura }}" toggle-criterio>
+                                {{ cev.ce.orden }}.{{ cev.orden }}.- {{ cev.texto|truncatechars:20 }}</th>
                             {% endfor %}
                         </tr>
                         </thead>
                         <tbody id="tbody_cuaderno{{ cuaderno.id }}">
                         {% for alumno in cuaderno.alumnos.all %}
                             {% for asignatura, ces in caas.items %}
-                                <tr id="tr_alumno{{ alumno.id }}" data-alumno="{{ alumno.id }}" style="color:red">
-                                    {% if forloop.first %}
+                                <tr id="tr_alumno{{ alumno.id }}" toggle-asignatura="{{ asignatura }}" data-alumno="{{ alumno.id }}">
+                                  
                                         <td class="fixed_column alumno" title="{{ alumno.gauser_extra_estudios.grupo.nombre }}"
-                                            rowspan="{{ num_asig }}">
-                                            <b>{{ alumno.gauser.last_name }}, <span class="firstname">{{ alumno.gauser.first_name }}</</b>
+                                            rowspan="{{ 1 }}">
+                                            
+                                            <span>
+                                                <b>{{ alumno.gauser.last_name }}, <span class="firstname">{{ alumno.gauser.first_name }}</b>
+                                            </span>
+                                            
                                         </td>
-                                    {% endif %}
+                                    
                                     {% if num_asig > 1 %}
                                         <td>{{ asignatura }}</td>
                                     {% endif %}
-                                    {#                                                        <td><b>{{ cuaderno|get_global_cal:alumno }}</b></td>#}
+                                    {#  <td><b>{{ cuaderno|get_global_cal:alumno }}</b></td>#}
                                     <td>
                                         <b>
-                                            {{ cuaderno|get_global_asignatura:asignatura|get_global_cal_asignatura:alumno }}</b>
+                                            {{ cuaderno|get_global_asignatura:asignatura|get_global_cal_asignatura:alumno }}
+                                        </b>
                                     </td>
                                     {% for cev in cuaderno.psec.areamateria.cevs %}
                                         {% ifchanged cev.ce %}
                                             {% if cev.ce in ces %}
-                                                <td>{{ cuaderno|get_ce_cal:cev.ce|get_calalum_ce:alumno }}</td>
+                                                <td  toggle-asignatura="{{ cev.ce.asignatura }}">{{ cuaderno|get_ce_cal:cev.ce|get_calalum_ce:alumno }}</td>
                                             {% else %}
-                                                <td>--</td>
+                                                <td toggle-asignatura="{{ cev.ce.asignatura }}">--</td>
                                             {% endif %}
                                         {% endifchanged %}
                                         {% if cev.ce in ces %}
-                                            <td>{{ cuaderno|get_cev_cals:cev|get_calalum_cev:alumno }}</td>
+                                            <td toggle-criterio toggle-asignatura="{{ cev.ce.asignatura }}">{{ cuaderno|get_cev_cals:cev|get_calalum_cev:alumno }}</td>
                                         {% else %}
-                                            <td>--</td>
+                                            <td toggle-criterio toggle-asignatura="{{ cev.ce.asignatura }}">--</td>
                                         {% endif %}
                                     {% endfor %}
                                 </tr>


### PR DESCRIPTION
En los cuadernos docentes de procedimientos, en la vista por competencias, aparecían todas las notas de todos los criterios y todas las competencias en una única tabla. Cuando manejábamos muchos datos y materias de ámbito que tienen 2  o más asignatura, la visualización de dichos datos era confusa.

Se han añadido botones de asignaturas y uno de criterios para mejorar el filtrado y visualización de las notas.