### PR TITLE
[58] Corrección filtrado por ronda y selección de anno en url

### DIFF
--- a/programaciones/templates/estadisticas_curso.html
+++ b/programaciones/templates/estadisticas_curso.html
@@ -19,7 +19,7 @@
     </style>
 
     <div>
-        <h4 id="title_page"><strong>Estadísticas Curso 2023/2024</strong></h4>
+        <h4 id="title_page"><strong>Estadísticas Curso {{ curso }}</strong></h4>
     </div>
 
     <div class="summary">
@@ -51,7 +51,7 @@
 
     <div>
         {% for ronda in rondas %}
-            {% with psecs=ronda.entidad|get_programaciones psecs_all=ronda.entidad|get_programaciones_incluidos_borradores %}
+            {% with psecs=ronda|get_programaciones_by_ronda psecs_all=ronda|get_programaciones_incluidos_borradores_by_ronda %}
                 <div style="margin-bottom: 10px; border-bottom: 1px solid gray;" data-ronda="{{ronda.id}}">
                     <div><b>{{ ronda }} {{ ronda.entidad }}</b></div>
                     <div style="color: green; font-weight: bold;" 

--- a/programaciones/templatetags/programaciones_extras.py
+++ b/programaciones/templatetags/programaciones_extras.py
@@ -57,6 +57,16 @@ def get_programaciones(e): #'e' es 'Entidad'
 def get_programaciones_incluidos_borradores(e): #'e' es 'Entidad'
     return ProgSec.objects.filter(pga__ronda=e.ronda, borrado=False).order_by('areamateria__curso')
 
+
+@register.filter
+def get_programaciones_by_ronda(ronda): 
+    return ProgSec.objects.filter(pga__ronda=ronda, borrado=False).exclude(tipo='BOR').order_by('areamateria__curso')
+
+
+@register.filter
+def get_programaciones_incluidos_borradores_by_ronda(ronda):
+    return ProgSec.objects.filter(pga__ronda=ronda, borrado=False).order_by('areamateria__curso')
+
 # Buscamos todos los cuadernos que pertenecen a una programación
 # Podemos seleccionar por tipo
 @register.filter

--- a/programaciones/urls.py
+++ b/programaciones/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
     path('crea_calalumce_cev/', views.crea_calalumce_cev),
     path('arregla_instrevals/', views.arregla_instrevals),
     path('estadistica_prog/', views.estadistica_prog),
-    path('estadisticas_curso/', views.estadisticas_curso),
+    path('estadisticas_curso/<str:anno>/', views.estadisticas_curso),
     path('arregla_cuaderno/<int:cuaderno_id>/<int:max_cal>/', views.arregla_cuaderno),
     path('arregla_cuaderno2/<int:cuaderno_id>/<int:max_cal>/', views.arregla_cuaderno2),
     path('arregla_cuaderno3/<int:cuaderno_id>/<int:max_cal>/', views.arregla_cuaderno3),

--- a/programaciones/views.py
+++ b/programaciones/views.py
@@ -3121,13 +3121,13 @@ def estadistica_prog(request):
 # número de profesores que han utilizado Gauss
 # número de centros que han utilizado Gauss
 
-def estadisticas_curso(request):
+def estadisticas_curso(request, anno):
     g_e = request.session['gauser_extra']
     
     # Query directa a base de datos para recoger todos los usuarios que han accedido por lo menos una vez a Gauss en el curso
     from django.db import connection
     with connection.cursor() as cursor:
-        query = "select count(*) from autenticar_gauser  where (last_login != date_joined and last_login >= '2023-09-01');"
+        query = "select count(*) from autenticar_gauser  where (last_login != date_joined and last_login >= '" + anno + "-09-01');"
         cursor.execute(query)
         rawData = cursor.fetchall()
         result = []
@@ -3136,9 +3136,10 @@ def estadisticas_curso(request):
         
     return render(request, "estadisticas_curso.html",
                   {
-                      'rondas': Ronda.objects.filter(inicio = "2023-09-01"),
+                      'rondas': Ronda.objects.filter(inicio = anno + "-09-01"),
                       'query' : query,
-                      'numero_usuarios': result[0][0]
+                      'numero_usuarios': result[0][0],
+                      'curso': anno + "/" + str(int(anno)+1)
                   })
 
 


### PR DESCRIPTION
Existía un error por el cual se seleccionaban siempre las programaciones de las últimas rondas creadas para una entidad, no la del curso anterior como se pretendía.

Añadimos además la posibilidad de seleccionar por url el año para el cual queremos las estadísticas.