### PR TITLE
[84] Imprimir informes por competencias resumidos

### DIFF
--- a/programaciones/templates/calificacc_all.html
+++ b/programaciones/templates/calificacc_all.html
@@ -6,6 +6,7 @@
         {% csrf_token %}
         <input type="hidden" id="action" name="action" value=""/>
         <div id="tabla_generar_informe"></div>
+        <div id="tabla_generar_informe_resumido" style="display: none;"></div>
         <textarea style="display: none;" id="textarea_tabla_generar_informe"
                   name="textarea_tabla_generar_informe"></textarea>
     </form>
@@ -14,7 +15,7 @@
 {% block final %}
     <script type="text/javascript">
         setTimeout(function () {
-            habilita(['s_file-pdf-o',]);
+            habilita(['s_file-pdf-o', 's_file-o']);
         }, 2000);
 
         function carga_alumnocc(alumno) {
@@ -22,6 +23,11 @@
                 function (data) {
                     if (data.ok) {
                         $('#tabla_generar_informe').append(data.informe);
+
+                        // Quitamos la parte extendida del informe
+                        $('#tabla_generar_informe_resumido').append(data.informe);
+                        $('#tabla_generar_informe_resumido').find(".informe_extendido").remove();
+                        
                     } else {
                         show_mensajes({title: '<i class="fa fa-warning"></i> Error', texto: data.msg});
                         $("#update_error").show().delay(1500).fadeOut();
@@ -41,6 +47,16 @@
             e.preventDefault();
             var style = '<style>table, td, th{border:1px}</style>';
             var html = $('#tabla_generar_informe').html();
+            $('#textarea_tabla_generar_informe').val(style + html);
+            $('#action').val('genera_pdf');
+            document.getElementById('{{ formname }}').submit();
+        });
+
+        //Informes resumidos
+        $('#file-o_sign').click(function (e) {
+            e.preventDefault();
+            var style = '<style>table, td, th{border:1px}</style>';
+            var html = $('#tabla_generar_informe_resumido').html();
             $('#textarea_tabla_generar_informe').val(style + html);
             $('#action').val('genera_pdf');
             document.getElementById('{{ formname }}').submit();

--- a/programaciones/templates/calificacc_alumno.html
+++ b/programaciones/templates/calificacc_alumno.html
@@ -65,91 +65,95 @@
    
     
 
-    <p style="font-weight: bold;font-size: large;" class="pagebreak no_visible">
-        Alumno: <span class="nombre_alumno_informe_cc">{{ alumno.gauser.get_full_name }}</span>
-    </p>
-    <p class="no_visible">
-        Curso: <span style="font-weight: bold;"
-                     class="nombre_curso_informe_cc">{% for curso in alumno.gauser_extra_estudios.grupo.cursos.all %}
-        {{ curso.nombre }}{% endfor %}</span>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        Grupo: <span style="font-weight: bold;"
-                     class="nombre_grupo_informe_cc">{{ alumno.gauser_extra_estudios.grupo.nombre }}</span>
-    </p>
-    <table style="width: 100%;">
-        <thead>
-        <tr>
-            <th colspan="3" style="text-align: center;">Perfil de salida (evaluación de los descriptores
-                operativos)
-            </th>
-        </tr>
-        <tr>
-            <th style="text-align: center;">Competencia Clave</th>
-            <th style="text-align: center;">Descriptores Operativos</th>
-            <th style="text-align: center;">Calificación</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for cc in ps.competenciaclave_set.all %}
-            {% for do in cc.descriptoroperativo_set.all %}
-                <tr>
-                    {% if forloop.first %}
-                        <td rowspan="{{ cc.descriptoroperativo_set.all|length }}">
-                            {{ cc.competencia }}
-                        </td>
-                    {% endif %}
-                    <td title="{{ do.clave }}">
-                        {{ do.texto }}
-                    </td>
-                    <td id="cal_do_informe{{ do.clave }}_{{ alumno.id }}" style="text-align: center;"
-                        contenteditable="true">{{ cal_dos|obtener_do_cal:do.clave }}</td>
-                </tr>
-            {% endfor %}
-        {% endfor %}
-        </tbody>
-    </table>
+    <div class="informe_extendido">
 
-    <p style="font-weight: bold;font-size: large;" class="pagebreak no_visible">
-        Alumno: <span class="nombre_alumno_informe_cc">{{ alumno.gauser.get_full_name }}</span>
-    </p>
-    <p class="no_visible">
-        Curso: <span style="font-weight: bold;"
-                     class="nombre_curso_informe_cc">{% for curso in alumno.gauser_extra_estudios.grupo.cursos.all %}
-        {{ curso.nombre }}{% endfor %}</span>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        Grupo: <span style="font-weight: bold;"
-                     class="nombre_grupo_informe_cc">{{ alumno.gauser_extra_estudios.grupo.nombre }}</span>
-    </p>
-    <table style="width: 100%;">
-        <thead>
-        <tr>
-            <th colspan="3" style="text-align: center;">
-                Evaluación de las competencias específicas vinculadas a cada asignatura
-            </th>
-        </tr>
-        <tr>
-            <th style="text-align: center;">Asignatura</th>
-            <th style="text-align: center;">Competencia Específica</th>
-            <th style="text-align: center;">Calificación</th>
-        </tr>
-        </thead>
-        {% for am in ams %}
-            <tbody class="tbody_am" id="tbody_am{{ am.id }}_{{ alumno.id }}">
-            {% for ce in am.competenciaespecifica_set.all %}
-                <tr>
-                    {% if forloop.first %}
-                        <td rowspan="{{ am.competenciaespecifica_set.all|length }}">
-                            {{ am.nombre }}
+        <p style="font-weight: bold;font-size: large;" class="pagebreak no_visible">
+            Alumno: <span class="nombre_alumno_informe_cc">{{ alumno.gauser.get_full_name }}</span>
+        </p>
+        <p class="no_visible">
+            Curso: <span style="font-weight: bold;"
+                         class="nombre_curso_informe_cc">{% for curso in alumno.gauser_extra_estudios.grupo.cursos.all %}
+            {{ curso.nombre }}{% endfor %}</span>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            Grupo: <span style="font-weight: bold;"
+                         class="nombre_grupo_informe_cc">{{ alumno.gauser_extra_estudios.grupo.nombre }}</span>
+        </p>
+        <table style="width: 100%;">
+            <thead>
+            <tr>
+                <th colspan="3" style="text-align: center;">Perfil de salida (evaluación de los descriptores
+                    operativos)
+                </th>
+            </tr>
+            <tr>
+                <th style="text-align: center;">Competencia Clave</th>
+                <th style="text-align: center;">Descriptores Operativos</th>
+                <th style="text-align: center;">Calificación</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for cc in ps.competenciaclave_set.all %}
+                {% for do in cc.descriptoroperativo_set.all %}
+                    <tr>
+                        {% if forloop.first %}
+                            <td rowspan="{{ cc.descriptoroperativo_set.all|length }}">
+                                {{ cc.competencia }}
+                            </td>
+                        {% endif %}
+                        <td title="{{ do.clave }}">
+                            {{ do.texto }}
                         </td>
-                    {% endif %}
-                    <td title="CE{{ ce.orden }}">
-                        {{ ce.nombre }}
-                    </td>
-                    <td id="cal_ce_informe{{ ce.id }}_{{ alumno.id }}" style="text-align: center;"
-                        contenteditable="true">{{ cal_ces|obtener_ce_cal:ce.id }}</td>
-                </tr>
+                        <td id="cal_do_informe{{ do.clave }}_{{ alumno.id }}" style="text-align: center;"
+                            contenteditable="true">{{ cal_dos|obtener_do_cal:do.clave }}</td>
+                    </tr>
+                {% endfor %}
             {% endfor %}
             </tbody>
-        {% endfor %}
-    </table>
+        </table>
+    
+        <p style="font-weight: bold;font-size: large;" class="pagebreak no_visible">
+            Alumno: <span class="nombre_alumno_informe_cc">{{ alumno.gauser.get_full_name }}</span>
+        </p>
+        <p class="no_visible">
+            Curso: <span style="font-weight: bold;"
+                         class="nombre_curso_informe_cc">{% for curso in alumno.gauser_extra_estudios.grupo.cursos.all %}
+            {{ curso.nombre }}{% endfor %}</span>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            Grupo: <span style="font-weight: bold;"
+                         class="nombre_grupo_informe_cc">{{ alumno.gauser_extra_estudios.grupo.nombre }}</span>
+        </p>
+        <table style="width: 100%;">
+            <thead>
+            <tr>
+                <th colspan="3" style="text-align: center;">
+                    Evaluación de las competencias específicas vinculadas a cada asignatura
+                </th>
+            </tr>
+            <tr>
+                <th style="text-align: center;">Asignatura</th>
+                <th style="text-align: center;">Competencia Específica</th>
+                <th style="text-align: center;">Calificación</th>
+            </tr>
+            </thead>
+            {% for am in ams %}
+                <tbody class="tbody_am" id="tbody_am{{ am.id }}_{{ alumno.id }}">
+                {% for ce in am.competenciaespecifica_set.all %}
+                    <tr>
+                        {% if forloop.first %}
+                            <td rowspan="{{ am.competenciaespecifica_set.all|length }}">
+                                {{ am.nombre }}
+                            </td>
+                        {% endif %}
+                        <td title="CE{{ ce.orden }}">
+                            {{ ce.nombre }}
+                        </td>
+                        <td id="cal_ce_informe{{ ce.id }}_{{ alumno.id }}" style="text-align: center;"
+                            contenteditable="true">{{ cal_ces|obtener_ce_cal:ce.id }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            {% endfor %}
+        </table>
+
+    </div>
 </div>

--- a/programaciones/views.py
+++ b/programaciones/views.py
@@ -4697,8 +4697,11 @@ def calificacc_all(request, grupo_id):
                   {
                       'formname': 'calificacc_all',
                       'iconos':
-                          ({'tipo': 'button', 'nombre': 'file-pdf-o', 'texto': 'PDF',
+                          ({'tipo': 'button', 'nombre': 'file-pdf-o', 'texto': 'PDF completo',
                             'title': 'Generar pdf de los informes competenciales',
+                            'permiso': 'libre'},
+                            {'tipo': 'button', 'nombre': 'file-o', 'texto': 'PDF resumido',
+                            'title': 'Generar pdf de los informes competenciales resumido',
                             'permiso': 'libre'},
                            # {'tipo': 'button', 'nombre': 'info-circle', 'texto': 'Ayuda', 'permiso': 'libre',
                            #  'title': 'Ayuda sobre el uso del repositorio de instrumentos de evaluación.'},


### PR DESCRIPTION
Se añade la funcionalidad de poder imprimir los informes por competencias con solo las competencias básicas, sin incluir ni las tables de descriptores operativos, ni competencias específicas