### PR TITLE
[87] Publicación de SAP para uso de toda la comunidad

### DIFF
--- a/programaciones/templates/repositorio_sap.html
+++ b/programaciones/templates/repositorio_sap.html
@@ -12,6 +12,25 @@
             border: lightgrey 1px solid;
             min-height: 100px;
         }
+
+        .pill {
+            font-size: 0.9em;
+            border: lightgrey 1px solid;
+            border-radius: 10px;
+            padding: 4px 6px;
+            margin: 0px 3px;
+        }
+
+        .publica {
+            color: #008CBA;
+            border: 1px solid #008CBA;
+        }
+
+        .privada {
+            color: gray;
+        }
+
+
     </style>
     <form action="" method="post" enctype="multipart/form-data" id="{{ formname }}" name="{{ formname }}">
         {% csrf_token %}
@@ -77,6 +96,20 @@
                                     }
                                 });
                         }
+                    }
+                });
+
+            });
+
+            $('body').on('click', '.compartir_sap', function () {
+                id = $(this).data('id');
+                $.post(url_repositorio_sap, {action: 'compartir_sap', id: id},
+                function (data) {
+                    if (data.ok) {
+                        location.href = "/repositorio_sap/"
+                        $("#update_ok").show().delay(1500).fadeOut();
+                    } else {
+                        $('#update_error').show().delay(1500).fadeOut();
                     }
                 });
 

--- a/programaciones/templates/repositorio_sap_accordion.html
+++ b/programaciones/templates/repositorio_sap_accordion.html
@@ -3,6 +3,13 @@
     style="border-bottom: dotted 1px black">
     <a href="#panel{{ sap.id }}">
         <i id="circle{{ sap.id }}" class="fa fa-plus-circle circle_icon"></i>
+        
+        {% if sap.publicar %}
+            <span class="pill publica">Pública</span>
+        {% else %}
+            <span class="pill privada">Privada</span>
+        {% endif %}
+        
         <b id="nombre{{ sap.id }}">
             {% if not sap.nombre %}<span style="color:red">Nueva Situación de aprendizaje</span>
                 {% else %}{{ sap.nombre }} -

--- a/programaciones/templates/repositorio_sap_accordion_content.html
+++ b/programaciones/templates/repositorio_sap_accordion_content.html
@@ -37,9 +37,11 @@
                 <li><a class="button alert borrar_sap tiny" data-id="{{ sap.id }}"
                        title="Borrar completamente esta situación de aprendizaje de la base de datos"><i
                         class="fa fa-trash-o"></i> Borrar</a></li>
-                <li><a class="button copiar_sap tiny" data-id="{{ sap.id }}"
+                <li><a class="button compartir_sap tiny" data-id="{{ sap.id }}"
                        title="Hacer una copia (un duplicado) de esta situación de aprendizaje"><i
-                        class="fa fa-copy"></i> Copiar</a>
+                        class="fa fa-share"></i> 
+                        {% if sap.publicar %}Dejar de compartir{% else %}Publicar para la comunidad{% endif %}
+                    </a>
                 </li>
             </ul>
         </div>

--- a/programaciones/views.py
+++ b/programaciones/views.py
@@ -3116,6 +3116,20 @@ def repositorio_sap(request):
                     return JsonResponse({'ok': False, 'msg': msg})
             except Exception as msg:
                 return JsonResponse({'ok': False, 'msg': str(msg)})
+        
+        elif action == 'compartir_sap':
+            try:
+                sapren = RepoSitApren.objects.get(id=request.POST['id'])
+                if sapren.autor.gauser == g_e.gauser:
+                    sapren.publicar = False if sapren.publicar else True
+                    sapren.save()
+                    return JsonResponse({'ok': True})
+                else:
+                    msg = 'No tienes permiso para compartir esta situación de aprendizaje.'
+                    return JsonResponse({'ok': False, 'msg': msg})
+            except Exception as msg:
+                return JsonResponse({'ok': False, 'msg': str(msg)})
+            
         elif action == 'open_accordion':
             try:
                 sap = RepoSitApren.objects.get(id=request.POST['id'])


### PR DESCRIPTION
Se ha arreglado la funcionalidad de poder compartir SAPs.
Antes, el atributo "publicar" de las `RepoSitApren` no se modificaba y estaba siempre a `False`.
Se ha cambiado el botón "COPIAR" de las SAPs del Banco para poder alternar entre True o False este campo. De esta forma, cuando una SAP es pública, puede ser encontrada por el resto de los docentes para utilizarlos en sus programaciones. Antes los docentes solo podían encontrar las suyas propias, ya que el atributo "publicar" siempre permanecía a False.